### PR TITLE
Fix 'no such file'

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ $ snaps-openrpc-generator init
 Generate artifacts based on your config
 
 ```shell
-$ snaps-openrpc-generator generate -c openrpc-generator-config.json
+$ snaps-openrpc-generator generate -c open-rpc-generator-config.json
 ```
 
 To build the snaps plugin:


### PR DESCRIPTION
Typo in
snaps-openrpc-generator generate -c openrpc-generator-config.json

(node:83730) UnhandledPromiseRejectionWarning: Error: ENOENT: no such file or directory, open 'openrpc-generator-config.json'